### PR TITLE
Enable to use '(single quote) to enclose color

### DIFF
--- a/sqs2irc.rb
+++ b/sqs2irc.rb
@@ -42,7 +42,7 @@ module IRC
           attrs = $1.scan(/ ((?:font|bg)="(?:[^"]*?)")/).map! { |a| a[0].split('=') }
           %w(font bg).each do |type|
             val = attrs.detect{ |attr| attr[0] == type }
-            color[type] = ::IRC::COLOR_CODE[val[1].delete('"').to_sym] if val
+            color[type] = ::IRC::COLOR_CODE[val[1].delete(%Q("')).to_sym] if val
           end
           code = nil
           if color['font']


### PR DESCRIPTION
colorタグ内で色を指定する際に"(ダブルクオート)だけではなく'(シングルクオート)でも値を囲めるようにしました
