### PR TITLE
Enable to use '(single quote) to enclose color(BugFix)

### DIFF
--- a/sqs2irc.rb
+++ b/sqs2irc.rb
@@ -39,7 +39,7 @@ module IRC
       def convert_color!(message)
         while (message =~ COLOR_PATTERN)
           color = {}
-          attrs = $1.scan(/ ((?:font|bg)="(?:[^"]*?)")/).map! { |a| a[0].split('=') }
+          attrs = $1.scan(/ ((?:font|bg)=["'](?:[^"']*?)["'])/).map! { |a| a[0].split('=') }
           %w(font bg).each do |type|
             val = attrs.detect{ |attr| attr[0] == type }
             color[type] = ::IRC::COLOR_CODE[val[1].delete(%Q("')).to_sym] if val


### PR DESCRIPTION
先のコミットではパース部分の正規表現に誤りがあったため'で囲った色が取得できていなかった
