### PR TITLE
data[type]周りでの例外を通知してbotが落ちないようにする

### DIFF
--- a/sqs2irc.rb
+++ b/sqs2irc.rb
@@ -103,7 +103,7 @@ module SQS2IRC
                       host: data['host'],
                       port: data['port']})
           rescue => e
-            irc.send(data['channel'], messages = [ e.message, msg.as_sns_message.body ])
+            irc.send(data['channel'], [e.message, msg.as_sns_message.body])
           end
         end
       end


### PR DESCRIPTION
data["notices"] や data["privmsgs"]がArray以外の時、プロセスが落ちていました。
エラーメッセージを吐いてポーリングが継続できるよう、例外処理を追加しました。

例外が発生したときのメッセージは以下のようになります。

```
[15:20] <watti-bot> undefined method `map' for "hoge":String
[15:20] <watti-bot> {"channel":"#watti-test", "nick":"wattibot", "notices":"hoge", "privmsgs":"fuga"}
[15:20] <watti-bot> undefined method `map' for "fuga":String
[15:20] <watti-bot> {"channel":"#watti-test", "nick":"wattibot", "notices":"hoge", "privmsgs":"fuga"}
```
